### PR TITLE
Fixes bug. No longer crashes when looking for Partner's User Object

### DIFF
--- a/Date-Night.xcodeproj/project.pbxproj
+++ b/Date-Night.xcodeproj/project.pbxproj
@@ -136,7 +136,6 @@
 		7401EF7723F1E941000C322B /* WaitingForResponseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitingForResponseView.swift; sourceTree = "<group>"; };
 		7448D19F23E895B4003A997C /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
 		7448D1A123E895DF003A997C /* SignUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpView.swift; sourceTree = "<group>"; };
-		7448D1A323E8B07D003A997C /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		7467518023F7169F00357610 /* SplashScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashScreenView.swift; sourceTree = "<group>"; };
 		7467518223F7293200357610 /* SplashScreenVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashScreenVC.swift; sourceTree = "<group>"; };
 		74ED85A185AA38B5892717CF /* Pods-Date-NightTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Date-NightTests.debug.xcconfig"; path = "Target Support Files/Pods-Date-NightTests/Pods-Date-NightTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -734,6 +733,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = RLQLZ26TC4;
 				INFOPLIST_FILE = "Date-Night/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -752,6 +752,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = RLQLZ26TC4;
 				INFOPLIST_FILE = "Date-Night/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Date-Night/Controllers/ProfileVC.swift
+++ b/Date-Night/Controllers/ProfileVC.swift
@@ -45,6 +45,7 @@ class ProfileSettingVC: UIViewController {
             switch result {
             case .success(let user):
                 self.profileSetting.partnerEmailDisplayLabel.text = user.partnerEmail
+                print("succesfully added partner email\(user.partnerEmail)")
             case .failure(let error):
                 print(error)
             }

--- a/Date-Night/Controllers/SignUpVC.swift
+++ b/Date-Night/Controllers/SignUpVC.swift
@@ -70,7 +70,7 @@ class SignUpVC: UIViewController {
                 
             case.success(let user):
                 FirestoreService.manager.createAppUser(user: AppUser(from: user, sessionID: nil, preferences: [])) { (result) in
-                    FirestoreService.manager.updateCurrentUser(firstName: displayName, photoURL: nil) { (result) in
+                    FirestoreService.manager.updateCurrentUser(userName: displayName, photoURL: nil) { (result) in
                         switch result {
                         case .failure(let error):
                             print(error)

--- a/Date-Night/Firebase/FirebaseAuthService.swift
+++ b/Date-Night/Firebase/FirebaseAuthService.swift
@@ -32,8 +32,8 @@ class FirebaseAuthService {
     //changes auth current user information
     func updateUserFields(name: String? = nil,photoURL: URL? = nil, completion: @escaping (Result<(),Error>) -> ()){
           let changeRequest = auth.currentUser?.createProfileChangeRequest()
-          if let firstName = name {
-              changeRequest?.displayName = firstName
+          if let userName = name {
+              changeRequest?.displayName = userName
           }
           if let photoURL = photoURL {
               changeRequest?.photoURL = photoURL

--- a/Date-Night/Firebase/FirestoreService.swift
+++ b/Date-Night/Firebase/FirestoreService.swift
@@ -48,15 +48,15 @@ class FirestoreService {
         }
     }
     
-    func updateCurrentUser(firstName: String? = nil, photoURL: URL? = nil, completion: @escaping (Result<(), Error>) -> ()){
+    func updateCurrentUser(userName: String? = nil, photoURL: URL? = nil, completion: @escaping (Result<(), Error>) -> ()){
         guard let userId = FirebaseAuthService.manager.currentUser?.uid else {
             //MARK: TODO - handle can't get current user
             return
         }
         var updateFields = [String:Any]()
         
-        if let firstName = firstName {
-            updateFields["firstName"] = firstName
+        if let userName = userName {
+            updateFields["userName"] = userName
         }
         
         


### PR DESCRIPTION
@phoenixmcknight 

Function in Firestore File that updated current user with display name added a first name field to User Object. This created an issue between having a userName field and a first name field so app would crash. Took care of this by erasing any reference to firstName and just keeping userName